### PR TITLE
INSIGHT-21157: Update to check for INSIGHT, and link to mediafly JIRA

### DIFF
--- a/validate-pr/dangerfile.js
+++ b/validate-pr/dangerfile.js
@@ -9,14 +9,14 @@ const _ = require('lodash');
 
 const pr = _.get(danger, 'github.pr');
 
-if (!_.startsWith(_.get(pr, 'title'), 'ISSUE-')) {
+if (!_.startsWith(_.get(pr, 'title'), 'ISSUE-') && !_.startsWith(_.get(pr, 'title'), 'INSIGHT-')) {
     fail('PR Validation Failed :disappointed:');
 }
 
 if (pr) {
     jiraIssue({
-        key: 'ISSUE',
-        url: 'https://insightsquared.atlassian.net/browse',
+        key: 'INSIGHT',
+        url: 'https://mediafly.atlassian.net/browse',
         location: 'title',
         format: (emoji, jiraUrls) => {
             return _.size(jiraUrls) === 1

--- a/validate-pr/dangerfile.js
+++ b/validate-pr/dangerfile.js
@@ -9,7 +9,7 @@ const _ = require('lodash');
 
 const pr = _.get(danger, 'github.pr');
 
-if (!_.startsWith(_.get(pr, 'title'), 'ISSUE-') && !_.startsWith(_.get(pr, 'title'), 'INSIGHT-')) {
+if (!_.startsWith(_.get(pr, 'title'), 'INSIGHT-')) {
     fail('PR Validation Failed :disappointed:');
 }
 


### PR DESCRIPTION
## Description
Update the PR validator to check for INSIGHT-XXX in PR titles and link to the Mediafly Jira instead of IS2 Jira.

## Tests [REQUIRED]
<!-- Address each of the following sections regarding testing -->

### Peer Testing
- [ ] I have had someone else on the engineering team test this change.

<!-- Pleases document discuss peer testing here. -->

### Manual Testing 
- [ ] I have manually tested this change.
can push a test PR to rest-server pointed at this branch to check I didn't break anything.
<!-- Please document HOW you tested it. "manually" is not enough, document the steps you performed. Screenshots can help here! -->

### Automated Tests
- [ ] I have identified existing automated tests, and/or added new automated tests.
n/a
<!-- Please document the automated tests that will verify this in the future. If relying on existing tests link to specific tests you think will catch regressions -->

### Post-release verification
- [ ] I have documented how I will verify this change in production
both new PRs and existing PR with new commits should get red Xs until their titles are updated.
<!-- Please document how you will verify this change in production. For example, a Datadog metric or dashboard you will watch, or a manual verification step you will perform. -->